### PR TITLE
Added apis for paper and purpur and directly from mojang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ while true; do
 
         # Get the download url from mojang
         download_url=$(curl -sX GET "https://launchermeta.mojang.com/mc/game/version_manifest.json" | jq -r --arg ver "$SERVER_VERSION" '.versions[] | select(.id == $ver) | .url' | xargs curl -s | jq -r '.downloads.server.url')
-		echo download_url
+
         # Download file
         wget -O "$SERVER_JAR" "$download_url"
 		break

--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,7 @@ if [ "$SERVER_SOFTWARE" = "paper" ]; then
 
     # Download file
     wget -O "$SERVER_JAR" "$download_url"
-else [ "$SERVER_SOFTWARE" = "purpur" ]; then
+elif [ "$SERVER_SOFTWARE" = "purpur" ]; then
     # Construct download URL
     download_url="https://api.purpurmc.org/v2/purpur/"$SERVER_VERSION"/latest/download"
     

--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,7 @@ while true; do
 
         # Download file
         wget -O "$SERVER_JAR" "$download_url"
-		break
+	break
     else
         echo "Not a valid response, try again"
     fi


### PR DESCRIPTION
 Always downloads the latest build for the selected version. Removes ability to download official server jar, but the 3rd party ones are objectively better anyways with plugins and bug fixes.